### PR TITLE
Travis and WinBuilder build fix (RProtoBuf)

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -9,3 +9,4 @@
 ^README\.Rmd$
 ^API$
 ^cran-comments\.md$
+^\.github

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: profile
 Title: Read, Manipulate, and Write Profiler Data
-Version: 1.0.1
-Date: 2018-05-24
+Version: 1.0.2
+Date: 2018-07-12
 Authors@R: 
     c(
       person("Kirill", "Müller", role = c("aut", "cre"), email = "krlmlr+r@mailbox.org"),
@@ -23,7 +23,7 @@ Suggests:
 Encoding: UTF-8
 LazyData: true
 Roxygen: list(markdown = TRUE, roclets = c("rd", "namespace", "collate", "pkgapi::api_roclet"))
-RoxygenNote: 6.0.1
+RoxygenNote: 6.0.1.9000
 Collate: 
     'api.R'
     'compat-purrr.R'

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: profile
 Title: Read, Manipulate, and Write Profiler Data
-Version: 1.0.0.9000
+Version: 1.0.1
 Date: 2018-05-24
 Authors@R: 
     c(

--- a/R/rprof-read.R
+++ b/R/rprof-read.R
@@ -17,8 +17,10 @@
 #' rprof_file <- system.file("samples/rprof/1.out", package = "profile")
 #' ds <- read_rprof(rprof_file)
 #' ds
-#' pprof_file <- tempfile("profile", fileext = ".pb.gz")
-#' write_pprof(ds, pprof_file)
+#' if (requireNamespace("RProtoBuf", quietly = TRUE)) {
+#'   pprof_file <- tempfile("profile", fileext = ".pb.gz")
+#'   write_pprof(ds, pprof_file)
+#' }
 read_rprof <- function(path, ..., version = "1.0") {
   stopifnot(version == get_default_meta()$value)
   rprof_ll <- read_rprof_ll(path)

--- a/README.Rmd
+++ b/README.Rmd
@@ -14,7 +14,7 @@ knitr::opts_chunk$set(
 ```
 # profile
 
-[![Travis build status](https://travis-ci.org/r-prof/profile.svg?branch=master)](https://travis-ci.org/r-prof/profile) [![Coverage status](https://codecov.io/gh/r-prof/profile/branch/master/graph/badge.svg)](https://codecov.io/github/r-prof/profile?branch=master) [![CRAN status](http://www.r-pkg.org/badges/version/profile)](https://cran.r-project.org/package=profile)
+[![Travis build status](https://travis-ci.org/r-prof/profile.svg?branch=master)](https://travis-ci.org/r-prof/profile) [![Coverage status](https://codecov.io/gh/r-prof/profile/branch/master/graph/badge.svg)](https://codecov.io/github/r-prof/profile?branch=master) [![CRAN status](https://www.r-pkg.org/badges/version/profile)](https://cran.r-project.org/package=profile)
 
 The goal of profile is to read and write files that contain run time profiling data. Currently, *profile* supports:
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 profile
 =======
 
-[![Travis build status](https://travis-ci.org/r-prof/profile.svg?branch=master)](https://travis-ci.org/r-prof/profile) [![Coverage status](https://codecov.io/gh/r-prof/profile/branch/master/graph/badge.svg)](https://codecov.io/github/r-prof/profile?branch=master) [![CRAN status](http://www.r-pkg.org/badges/version/profile)](https://cran.r-project.org/package=profile)
+[![Travis build status](https://travis-ci.org/r-prof/profile.svg?branch=master)](https://travis-ci.org/r-prof/profile) [![Coverage status](https://codecov.io/gh/r-prof/profile/branch/master/graph/badge.svg)](https://codecov.io/github/r-prof/profile?branch=master) [![CRAN status](https://www.r-pkg.org/badges/version/profile)](https://cran.r-project.org/package=profile)
 
 The goal of profile is to read and write files that contain run time profiling data. Currently, *profile* supports:
 

--- a/man/read_rprof.Rd
+++ b/man/read_rprof.Rd
@@ -52,6 +52,8 @@ or (in newer versions) via \code{go get github.com/google/pprof}.
 rprof_file <- system.file("samples/rprof/1.out", package = "profile")
 ds <- read_rprof(rprof_file)
 ds
-pprof_file <- tempfile("profile", fileext = ".pb.gz")
-write_pprof(ds, pprof_file)
+if (requireNamespace("RProtoBuf", quietly = TRUE)) {
+  pprof_file <- tempfile("profile", fileext = ".pb.gz")
+  write_pprof(ds, pprof_file)
+}
 }


### PR DESCRIPTION
You can see the travis green build in https://github.com/creggian/profile/tree/buildfix where I changed the readme so to point to my travis account (changes not present in this branch)

WinBuild green build here https://win-builder.r-project.org/a16S2BLJlXmY/00check.log or below

Local check log is below below

Few notes:
- See also the new version number and let me know if that is ok.
- 'RoxygenNote: 6.0.1.9000' has been generated automatically with `roxygen2::roxygenise()` command
- I updated the http to https in the READMEs, but still I got the WARNING (locally only) because of `TlsExceptionHostPort`

**WinBuild check**
```
* using log directory 'd:/RCompile/CRANguest/R-devel/profile.Rcheck'
* using R Under development (unstable) (2018-07-01 r74950)
* using platform: x86_64-w64-mingw32 (64-bit)
* using session charset: ISO8859-1
* checking for file 'profile/DESCRIPTION' ... OK
* this is package 'profile' version '1.0.2'
* package encoding: UTF-8
* checking CRAN incoming feasibility ... NOTE
Maintainer: 'Kirill M�ller <nophiq@gmail.com>'

New maintainer:
  Kirill M�ller <nophiq@gmail.com>
Old maintainer(s):
  Kirill M�ller <krlmlr+r@mailbox.org>
* checking package namespace information ... OK
* checking package dependencies ... OK
* checking if this is a source package ... OK
* checking if there is a namespace ... OK
* checking for hidden files and directories ... OK
* checking for portable file names ... OK
* checking serialization versions ... OK
* checking whether package 'profile' can be installed ... OK
* checking installed package size ... OK
* checking package directory ... OK
* checking DESCRIPTION meta-information ... OK
* checking top-level files ... OK
* checking for left-over files ... OK
* checking index information ... OK
* checking package subdirectories ... OK
* checking R files for non-ASCII characters ... OK
* checking R files for syntax errors ... OK
* loading checks for arch 'i386'
** checking whether the package can be loaded ... OK
** checking whether the package can be loaded with stated dependencies ... OK
** checking whether the package can be unloaded cleanly ... OK
** checking whether the namespace can be loaded with stated dependencies ... OK
** checking whether the namespace can be unloaded cleanly ... OK
** checking loading without being on the library search path ... OK
** checking use of S3 registration ... OK
* loading checks for arch 'x64'
** checking whether the package can be loaded ... OK
** checking whether the package can be loaded with stated dependencies ... OK
** checking whether the package can be unloaded cleanly ... OK
** checking whether the namespace can be loaded with stated dependencies ... OK
** checking whether the namespace can be unloaded cleanly ... OK
** checking loading without being on the library search path ... OK
** checking use of S3 registration ... OK
* checking dependencies in R code ... OK
* checking S3 generic/method consistency ... OK
* checking replacement functions ... OK
* checking foreign function calls ... OK
* checking R code for possible problems ... [4s] OK
* checking Rd files ... OK
* checking Rd metadata ... OK
* checking Rd line widths ... OK
* checking Rd cross-references ... OK
* checking for missing documentation entries ... OK
* checking for code/documentation mismatches ... OK
* checking Rd \usage sections ... OK
* checking Rd contents ... OK
* checking for unstated dependencies in examples ... OK
* checking examples ...
** running examples for arch 'i386' ... [2s] OK
** running examples for arch 'x64' ... [1s] OK
* checking for unstated dependencies in 'tests' ... OK
* checking tests ...
** running tests for arch 'i386' ... [3s] OK
  Running 'testthat.R' [3s]
** running tests for arch 'x64' ... [4s] OK
  Running 'testthat.R' [3s]
* checking PDF version of manual ... OK
* DONE
Status: 1 NOTE
```

**Local check with _R_CHECK_FORCE_SUGGESTS_=FALSE R CMD check --as-cran profile_1.0.2.tar.gz**
```
nophiq@n:~/github$ _R_CHECK_FORCE_SUGGESTS_=FALSE R CMD check --as-cran profile_1.0.2.tar.gz
* using log directory ‘/home/nophiq/github/profile.Rcheck’
* using R version 3.4.4 (2018-03-15)
* using platform: x86_64-pc-linux-gnu (64-bit)
* using session charset: UTF-8
* using option ‘--as-cran’
* checking for file ‘profile/DESCRIPTION’ ... OK
* this is package ‘profile’ version ‘1.0.2’
* package encoding: UTF-8
* checking CRAN incoming feasibility ... Note_to_CRAN_maintainers
Maintainer: ‘Kirill Müller <krlmlr+r@mailbox.org>’
* checking package namespace information ... OK
* checking package dependencies ... NOTE
Package suggested but not available for checking: ‘RProtoBuf’
* checking if this is a source package ... OK
* checking if there is a namespace ... OK
* checking for executable files ... OK
* checking for hidden files and directories ... OK
* checking for portable file names ... OK
* checking for sufficient/correct file permissions ... OK
* checking whether package ‘profile’ can be installed ... OK
* checking installed package size ... OK
* checking package directory ... OK
* checking DESCRIPTION meta-information ... OK
* checking top-level files ... WARNING
Conversion of ‘README.md’ failed:
pandoc: Could not fetch https://www.r-pkg.org/badges/version/profile
TlsExceptionHostPort (HandshakeFailed Error_EOF) "www.r-pkg.org" 443
* checking for left-over files ... OK
* checking index information ... OK
* checking package subdirectories ... OK
* checking R files for non-ASCII characters ... OK
* checking R files for syntax errors ... OK
* checking whether the package can be loaded ... OK
* checking whether the package can be loaded with stated dependencies ... OK
* checking whether the package can be unloaded cleanly ... OK
* checking whether the namespace can be loaded with stated dependencies ... OK
* checking whether the namespace can be unloaded cleanly ... OK
* checking loading without being on the library search path ... OK
* checking use of S3 registration ... OK
* checking dependencies in R code ... OK
* checking S3 generic/method consistency ... OK
* checking replacement functions ... OK
* checking foreign function calls ... OK
* checking R code for possible problems ... OK
* checking Rd files ... OK
* checking Rd metadata ... OK
* checking Rd line widths ... OK
* checking Rd cross-references ... OK
* checking for missing documentation entries ... OK
* checking for code/documentation mismatches ... OK
* checking Rd \usage sections ... OK
* checking Rd contents ... OK
* checking for unstated dependencies in examples ... OK
* checking examples ... OK
* checking for unstated dependencies in ‘tests’ ... OK
* checking tests ...
  Running ‘testthat.R’
 OK
* checking PDF version of manual ... WARNING
LaTeX errors when creating PDF version.
This typically indicates Rd problems.
* checking PDF version of manual without hyperrefs or index ... OK
* DONE

Status: 2 WARNINGs, 1 NOTE
See
  ‘/home/nophiq/github/profile.Rcheck/00check.log’
for details.
```